### PR TITLE
Frank dist

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,16 +9,9 @@ module.exports = {
     'jest-formatting',
     'sort-imports-es6-autofix',
   ],
-  extends: [
-    'eslint:recommended',
-    'plugin:prettier/recommended',
-    'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:jest-formatting/strict',
-  ],
+  extends: ['eslint:recommended', 'plugin:prettier/recommended', 'plugin:jest-formatting/strict'],
   /* eslint-enable sort-keys */
   rules: {
-    '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],
     'arrow-body-style': ['error', 'as-needed'],
     eqeqeq: 'error',
     'import/newline-after-import': 'error',
@@ -26,7 +19,11 @@ module.exports = {
     'import/no-extraneous-dependencies': [
       'error',
       {
-        devDependencies: ['**/*.@(test|spec).@(js|ts)', '**/tests/lib/**/*.@(js|ts)'],
+        devDependencies: [
+          '**/*.@(test|spec).@(js|ts)',
+          '**/tests/lib/**/*.@(js|ts)',
+          'scripts/*.@(js|ts)',
+        ],
       },
     ],
     'import/no-named-as-default-member': 'error',
@@ -34,6 +31,7 @@ module.exports = {
     'no-console': 'error',
     'no-param-reassign': 'error',
     'no-unsafe-optional-chaining': 'error',
+    'no-unused-vars': ['error', { ignoreRestSiblings: true }],
     'no-use-before-define': 'error',
     'prettier/prettier': ['error'],
     'sort-imports-es6-autofix/sort-imports-es6': ['error', { ignoreCase: true }],
@@ -41,6 +39,18 @@ module.exports = {
     yoda: 'error',
   },
   /* eslint-disable sort-keys */
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      extends: [
+        'plugin:@typescript-eslint/eslint-recommended',
+        'plugin:@typescript-eslint/recommended',
+      ],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': ['warn', { allowExpressions: true }],
+      },
+    },
+  ],
   ignorePatterns: ['/lib'],
   env: {
     node: true,

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,11 @@ dist
 # IDE files
 .idea/
 
+# release files
+lib/package.json
+lib/README.md
+lib/LICENSE
+
 # local files
 src/sandbox/
 lib/sandbox/

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,9 +28,11 @@
         "eslint-plugin-jest-formatting": "^3.0.0",
         "eslint-plugin-prettier": "^3.4.0",
         "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
+        "fs-extra": "^10.1.0",
         "husky": "^4.3.8",
         "jest": "^27.0.4",
         "prettier": "^2.2.1",
+        "rimraf": "^3.0.2",
         "ts-expect": "^1.3.0",
         "ts-jest": "^27.0.2",
         "ts-node": "^9.1.1",
@@ -3214,6 +3216,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs-extra/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4878,6 +4903,27 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonfile/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/kleur": {
@@ -9324,6 +9370,25 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -10566,6 +10631,24 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "kleur": {

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "pardot-client",
   "version": "1.0.1",
   "description": "A client for Pardot API v3 and v4, with support for Salesforce SSO",
-  "main": "lib/index",
-  "typings": "lib/index",
+  "main": "index",
+  "typings": "index",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint --ext .ts,.js .",
     "test": "jest --coverage",
-    "jest": "jest"
+    "jest": "jest",
+    "release:prepare": "node scripts/frank-lib.js",
+    "release": "npm run release:prepare && npm publish ./lib --tag latest"
   },
   "husky": {
     "hooks": {
@@ -50,12 +52,15 @@
     "eslint-plugin-jest-formatting": "^3.0.0",
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
+    "fs-extra": "^10.1.0",
     "husky": "^4.3.8",
     "jest": "^27.0.4",
     "prettier": "^2.2.1",
+    "rimraf": "^3.0.2",
     "ts-expect": "^1.3.0",
     "ts-jest": "^27.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.3.2"
-  }
+  },
+  "private": true
 }

--- a/scripts/frank-lib.js
+++ b/scripts/frank-lib.js
@@ -1,0 +1,44 @@
+// based on frank-dist.js from https://github.com/Izhaki/regraph
+
+/* eslint-disable no-console */
+const { resolve, join, basename } = require('path');
+const { readFile, writeFile, copy } = require('fs-extra');
+
+const packagePath = process.cwd();
+const libPath = join(packagePath, './lib');
+
+const writeJson = (targetPath, obj) => writeFile(targetPath, JSON.stringify(obj, null, 2), 'utf8');
+
+async function createPackageFile() {
+  const packageData = await readFile(resolve(packagePath, './package.json'), 'utf8');
+  const { scripts, devDependencies, husky, ...packageOthers } = JSON.parse(packageData);
+  const newPackageData = {
+    ...packageOthers,
+    private: false,
+  };
+
+  const targetPath = resolve(libPath, './package.json');
+
+  await writeJson(targetPath, newPackageData);
+  console.log(`Created package.json in ${targetPath}`);
+}
+
+async function includeFileInBuild(file) {
+  const sourcePath = resolve(packagePath, file);
+  const targetPath = resolve(libPath, basename(file));
+  await copy(sourcePath, targetPath);
+  console.log(`Copied ${sourcePath} to ${targetPath}`);
+}
+
+async function run() {
+  try {
+    await createPackageFile();
+    await includeFileInBuild('./README.md');
+    await includeFileInBuild('./LICENSE');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+}
+
+run();


### PR DESCRIPTION
Publish just the lib/ directory to npm.  This allows importing from the object files without the lib/ prefix, and makes the package smaller by omitted the src/ and docs/ directories.

frank-lib.js based on frank-dist.js from [regraph](https://github.com/Izhaki/regraph).